### PR TITLE
makes allocation an input

### DIFF
--- a/src/app/components/BudgetTable/BudgetTable.tsx
+++ b/src/app/components/BudgetTable/BudgetTable.tsx
@@ -52,6 +52,10 @@ export default function BudgetTable() {
     )
   }
 
+  const handleRowInputSelect = (name: string) => {
+    setSelectedCategories(new Set([name]))
+  }
+
   return (
     <div className="flex w-full flex-col text-xs">
       {/* Model underly */}
@@ -99,6 +103,7 @@ export default function BudgetTable() {
           }
           selected={selectedCategories.has(category.name)}
           toggleSelect={categorySelectionToggle(category.name)}
+          onSelect={handleRowInputSelect}
         />
       ))}
     </div>

--- a/src/app/components/BudgetTable/BudgetTableRow.tsx
+++ b/src/app/components/BudgetTable/BudgetTableRow.tsx
@@ -1,6 +1,7 @@
 import EditCategoryModal from './EditCategoryModal'
 import useBudgetStore from '../../stores/transactionStore'
 import { formatCentsToDollarString } from '../../util/utils'
+import { useState, useCallback, useRef } from 'react'
 
 interface BudgetTableRowProps {
   name: string
@@ -11,6 +12,7 @@ interface BudgetTableRowProps {
 }
 export default function BudgetTableRow({
   name,
+
   selected,
   editing,
   toggleEdit,
@@ -20,6 +22,22 @@ export default function BudgetTableRow({
   const allocated = categories.find((c) => c.name === name)?.allocated || 0
   const activityCents = getBalanceByCategory(name)
   const availableCents = allocated + activityCents
+  const [editAllocatedInput, setEditAllocatedInput] = useState((allocated / 100).toFixed(2))
+
+  const inputRef = useRef<HTMLInputElement>(null)
+
+
+  const handleKeyDown = useCallback((e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      const newValue = parseFloat(editAllocatedInput)
+      if (!isNaN(newValue)) {
+        // updateCategoryAllocation(name, Math.round(newValue * 100))
+        //replace with real setter function
+        console.log("allocation updated")
+        inputRef.current?.blur()
+      }
+    }
+  }, [editAllocatedInput, name])
   return (
     <div
       className={`flex items-stretch border-b border-gray-300 py-2 pr-4 ${selected ? 'bg-indigo-200' : 'bg-white'}`}
@@ -67,11 +85,19 @@ export default function BudgetTableRow({
         </div>
       </div>
       <div className="flex w-[15%] justify-end">
-        <div className="truncate px-2 py-0.5">
-          {allocated >= 0
-            ? `$${(allocated / 100).toFixed(2)}`
-            : `-$${(-allocated / 100).toFixed(2)}`}
-        </div>
+        <input
+          ref={inputRef}
+          type="number"
+          className={`w-full truncate px-2 text-right rounded ${selected ? 'border border-indigo-500 cursor-text' : 'hover:border hover:border-indigo-500 hover:cursor-text'}`}
+          value={editAllocatedInput}
+          onChange={(e) => {
+            setEditAllocatedInput(e.target.value)
+          }}
+          onKeyDown={handleKeyDown}
+          onBlur={() => setEditAllocatedInput((allocated / 100).toFixed(2))}
+          onClick={(e) => e.stopPropagation()}
+          onFocus={(e) => e.target.select()}
+        />
       </div>
       <div className="flex w-[15%] justify-end">
         <div className="truncate px-2 py-0.5">

--- a/src/app/components/BudgetTable/BudgetTableRow.tsx
+++ b/src/app/components/BudgetTable/BudgetTableRow.tsx
@@ -9,6 +9,7 @@ interface BudgetTableRowProps {
   editing: boolean
   toggleEdit: () => void
   toggleSelect: () => void
+  onSelect: (name: string) => void
 }
 export default function BudgetTableRow({
   name,
@@ -17,6 +18,7 @@ export default function BudgetTableRow({
   editing,
   toggleEdit,
   toggleSelect,
+  onSelect, 
 }: BudgetTableRowProps) {
   const { categories, getBalanceByCategory } = useBudgetStore()
   const allocated = categories.find((c) => c.name === name)?.allocated || 0
@@ -26,6 +28,10 @@ export default function BudgetTableRow({
 
   const inputRef = useRef<HTMLInputElement>(null)
 
+  const handleInputClick = (e: React.MouseEvent<HTMLInputElement>) => {
+    e.stopPropagation()
+    onSelect(name)
+  }
 
   const handleKeyDown = useCallback((e: React.KeyboardEvent<HTMLInputElement>) => {
     if (e.key === 'Enter') {
@@ -95,7 +101,7 @@ export default function BudgetTableRow({
           }}
           onKeyDown={handleKeyDown}
           onBlur={() => setEditAllocatedInput((allocated / 100).toFixed(2))}
-          onClick={(e) => e.stopPropagation()}
+          onClick={handleInputClick}
           onFocus={(e) => e.target.select()}
         />
       </div>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit f13296bd12fcb7db47ccdebfa3c916a55485905b  | 
|--------|--------|

### Summary:
This PR makes allocation an editable input in `BudgetTableRow`, allowing direct user input and selection handling in `BudgetTable`.

**Key points**:
- Added `handleRowInputSelect` function in `src/app/components/BudgetTable/BudgetTable.tsx` to manage row selection.
- Modified `BudgetTableRow` component in `src/app/components/BudgetTable/BudgetTableRow.tsx` to include an input field for allocation.
- Added `onSelect` prop to `BudgetTableRow` to handle input click events.
- Implemented `handleInputClick` and `handleKeyDown` in `BudgetTableRow` to manage input focus and submission.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->