### PR TITLE
fix unescaped character error

### DIFF
--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -45,7 +45,7 @@ export default function Error({
     <div className="flex flex-col items-center justify-center min-h-screen p-4">
       <h2 className="text-xl font-bold mb-4">Oops! Something went wrong</h2>
       <p className="text-gray-600 mb-4">
-        We've logged the error and we'll look into it.
+        We&apos;ve logged the error and we&apos;ll look into it.
       </p>
       <button
         onClick={() => {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix unescaped apostrophe in JSX text in `error.tsx`.
> 
>   - **Behavior**:
>     - Fix unescaped apostrophe in `error.tsx` JSX text, changing `We've` to `We\&apos;ve` and `we'll` to `we\&apos;ll`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=fractal-bootcamp%2Fwemadeabudget&utm_source=github&utm_medium=referral)<sup> for d9e359eb2becaa655f666b1e9ab7136735e91533. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->